### PR TITLE
Print the executed kcov command in verbose mode

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -1,6 +1,7 @@
 use std::process::Command;
 use std::convert::AsRef;
 use std::ffi::OsStr;
+use std::fmt;
 use std::env::var_os;
 
 use clap::ArgMatches;
@@ -10,6 +11,13 @@ use errors::Error;
 pub struct Cmd {
     cmd: Command,
     subcommand: &'static str,
+}
+
+impl fmt::Display for Cmd {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use std::fmt::Debug;
+        self.cmd.fmt(f)
+    }
 }
 
 enum ArgType {

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,11 +156,14 @@ fn run(matches: &ArgMatches) -> Result<(), Error> {
     for test in tests {
         let mut pre_cov_path = cov_path.clone();
         pre_cov_path.push(test.file_name().unwrap());
-        try!(Cmd::new(&kcov_path, "--exclude-pattern=/.cargo")
+        let cmd = Cmd::new(&kcov_path, "--exclude-pattern=/.cargo")
             .env("LD_LIBRARY_PATH", ":", "target/debug/deps")
             .args(&kcov_args)
-            .args(&[&pre_cov_path, &test])
-            .run_kcov());
+            .args(&[&pre_cov_path, &test]);
+        if is_verbose {
+            write_msg("Running", &cmd.to_string());
+        }
+        try!(cmd.run_kcov());
         merge_cov_paths.push(pre_cov_path);
     }
 
@@ -168,7 +171,11 @@ fn run(matches: &ArgMatches) -> Result<(), Error> {
     if let Some(opt) = coveralls_option {
         merge_cmd = merge_cmd.args(&[opt]);
     }
-    try!(merge_cmd.args(&merge_cov_paths).run_kcov());
+    merge_cmd = merge_cmd.args(&merge_cov_paths);
+    if is_verbose {
+        write_msg("Running", &merge_cmd.to_string());
+    }
+    try!(merge_cmd.run_kcov());
 
     Ok(())
 }


### PR DESCRIPTION
Today I had a [`problem`](https://github.com/kennytm/cargo-kcov/issues/2) with `cargo-kcov` that could be solved more easily if the execute `kcov` command was printed.

This is similar to how `cargo build` prints the executed `rustc` command. To use the same style in the output one must port [this](https://github.com/rust-lang/cargo/blob/02eaab39039ac80cb978be867c2ce05efc508583/src/cargo/util/process_builder.rs#L19-L29) to `cargo-kcov`.