### PR TITLE
Improved install_kcov.sh

### DIFF
--- a/src/install_kcov.sh
+++ b/src/install_kcov.sh
@@ -4,10 +4,9 @@ set -eu
 
 KCOV_VERSION=34
 
-rm -rf v${KCOV_VERSION}.tar.gz kcov-${KCOV_VERSION}/
+rm -rf kcov-${KCOV_VERSION}/
 
-wget https://github.com/SimonKagstrom/kcov/archive/v${KCOV_VERSION}.tar.gz
-tar xzf v${KCOV_VERSION}.tar.gz
+wget https://github.com/SimonKagstrom/kcov/archive/v${KCOV_VERSION}.tar.gz -O - | tar xz
 cd kcov-${KCOV_VERSION}
 mkdir build
 cd build

--- a/src/install_kcov.sh
+++ b/src/install_kcov.sh
@@ -13,5 +13,5 @@ mkdir build
 cd build
 cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 make
-cp src/kcov src/libkcov_sowrapper.so ~/.cargo/bin
+cp src/kcov src/libkcov_sowrapper.so "${CARGO_HOME:-$HOME/.cargo}/bin"
 


### PR DESCRIPTION
- Respecting `$CARGO_HOME` for non default installations.
- Directly untar archive without file.