### PR TITLE
Download and install the latest kcov release

### DIFF
--- a/src/install_kcov.sh
+++ b/src/install_kcov.sh
@@ -2,15 +2,33 @@
 
 set -eu
 
-KCOV_VERSION=34
+KCOV_DEFAULT_VERSION="v34"
+GITHUB_KCOV="https://api.github.com/repos/SimonKagstrom/kcov/releases/latest"
+KCOV_VERSION=
+
+# Usage: download and install the latest kcov version by default.
+# Fall back to $KCOV_DEFAULT_VERSION from the kcov archive if the latest is unavailable.
+
+KCOV_INFO=$(curl -s ${GITHUB_KCOV})
+KCOV_VERSION=$(echo "${KCOV_INFO}" | grep -Po '"tag_name":\K.*?[^\\]",')
+
+if [ -z ${KCOV_VERSION} ]; then
+    KCOV_TGZ="https://github.com/SimonKagstrom/kcov/archive/${KCOV_DEFAULT_VERSION}.tar.gz"
+else
+    # Extract the version number from the json parsed info.
+    # Format:
+    #  "v35",
+    KCOV_VERSION=$(echo "${KCOV_VERSION}" | cut -d\" -f2) # -> v35
+    KCOV_TGZ=$(echo "${KCOV_INFO}" | grep -Po '"tarball_url":\K.*?[^\\]",' | cut -d\" -f2)
+fi
 
 rm -rf kcov-${KCOV_VERSION}/
+mkdir kcov-${KCOV_VERSION}
+wget "${KCOV_TGZ}" -O - | tar xzvf - -C kcov-${KCOV_VERSION} --strip-components 1
 
-wget https://github.com/SimonKagstrom/kcov/archive/v${KCOV_VERSION}.tar.gz -O - | tar xz
 cd kcov-${KCOV_VERSION}
 mkdir build
 cd build
 cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 make
 cp src/kcov src/libkcov_sowrapper.so "${CARGO_HOME:-$HOME/.cargo}/bin"
-


### PR DESCRIPTION
Have cargo-kcov retrieve the latest release of kcov via GitHub's Release
API [1]. If unable to determine the latest release, default to 'v34'
from kcov's archive [2].

Fixes #26

[1] https://developer.github.com/v3/repos/releases/
[2] https://github.com/SimonKagstrom/kcov/archive

Signed-off-by: Alexandra Ghecenco <aghecen@amazon.com>