### PR TITLE
Update print install kcov sh script

### DIFF
--- a/src/install_kcov.sh
+++ b/src/install_kcov.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -euo pipefail
+set -eu
 
 KCOV_DEFAULT_VERSION="v35"
 GITHUB_KCOV="https://api.github.com/repos/SimonKagstrom/kcov/releases/latest"
@@ -17,15 +17,24 @@ rm -rf kcov-${KCOV_VERSION}/
 mkdir kcov-${KCOV_VERSION}
 curl -L --retry 3 "${KCOV_TGZ}" | tar xzvf - -C kcov-${KCOV_VERSION} --strip-components 1
 
+num_proc=1
+if [ "${PARALLEL_BUILD:-}" != "" ]; then
+    if [ "$(uname -s)" = "Darwin" ]; then
+        num_proc=$(sysctl -n hw.ncpu)
+    else
+        num_proc=$(nproc)
+    fi
+fi
+
 cd kcov-${KCOV_VERSION}
 mkdir build
 cd build
 if [ "$(uname)" = Darwin ]; then
     cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -GXcode ..
     xcodebuild -configuration Release
-    cp src/Release/kcov src/Release/libkcov_system_lib.so "${CARGO_HOME:-$HOME/.cargo}/bin"
+    cp src/Release/kcov src/Release/libkcov_system_lib.so "${CARGO_HOME:-${HOME}/.cargo}/bin"
 else
     cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-    make
-    cp src/kcov src/libkcov_sowrapper.so "${CARGO_HOME:-$HOME/.cargo}/bin"
+    make -j ${num_proc}
+    cp src/kcov src/libkcov_sowrapper.so "${CARGO_HOME:-${HOME}/.cargo}/bin"
 fi

--- a/src/install_kcov.sh
+++ b/src/install_kcov.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -eu
+set -euo pipefail
 
 KCOV_DEFAULT_VERSION="v35"
 GITHUB_KCOV="https://api.github.com/repos/SimonKagstrom/kcov/releases/latest"
@@ -9,13 +9,13 @@ GITHUB_KCOV="https://api.github.com/repos/SimonKagstrom/kcov/releases/latest"
 # Fall back to $KCOV_DEFAULT_VERSION from the kcov archive if the latest is unavailable.
 
 KCOV_VERSION=$(curl -s ${GITHUB_KCOV} | jq -Mr .tag_name || echo)
-KCOV_VERSION=${KCOV_VERSION+$KCOV_DEFAULT_VERSION}
+KCOV_VERSION=${KCOV_VERSION:-$KCOV_DEFAULT_VERSION}
 
-KCOV_TGZ="https://github.com/SimonKagstrom/kcov/archive/${KCOV_DEFAULT_VERSION}.tar.gz"
+KCOV_TGZ="https://github.com/SimonKagstrom/kcov/archive/${KCOV_VERSION}.tar.gz"
 
 rm -rf kcov-${KCOV_VERSION}/
 mkdir kcov-${KCOV_VERSION}
-curl -L "${KCOV_TGZ}" | tar xzvf - -C kcov-${KCOV_VERSION} --strip-components 1
+curl -L --retry 3 "${KCOV_TGZ}" | tar xzvf - -C kcov-${KCOV_VERSION} --strip-components 1
 
 cd kcov-${KCOV_VERSION}
 mkdir build

--- a/src/install_kcov.sh
+++ b/src/install_kcov.sh
@@ -21,11 +21,18 @@ mkdir kcov-${KCOV_VERSION}
 curl -L --retry 3 "${KCOV_TGZ}" | tar xzvf - -C kcov-${KCOV_VERSION} --strip-components 1
 
 num_proc=1
+# If PARALLEL_BUILD environment variable is set then parallel build is enabled
 if [ "${PARALLEL_BUILD:-}" != "" ]; then
-    if command_exists nproc; then
-        num_proc=$(nproc)
-    elif command_exists sysctl; then
-        num_proc=$(sysctl -n hw.ncpu)
+    # If PARALLEL_BUILD content is a number then use it as number of parallel jobs
+    if [ ! -z "${PARALLEL_BUILD##*[!0-9]*}" ]; then
+        num_proc=${PARALLEL_BUILD}
+    else
+        # Try to determine the number of available CPUs
+        if command_exists nproc; then
+            num_proc=$(nproc)
+        elif command_exists sysctl; then
+            num_proc=$(sysctl -n hw.ncpu)
+        fi
     fi
 fi
 


### PR DESCRIPTION
The changes provided by this PR allow to:
 * Install the latest `kcov` version (it was installing `KCOV_DEFAULT_VERSION` independently from `KCOV_VERSION` been identified)
 * Make build use all the available processors (faster build) -> this is only enabled if `PARALLEL_BUILD` is defined
 * Make curling a bit more resilient to errors