### PR TITLE
Make GitHub api usage more resilient to error

### DIFF
--- a/src/install_kcov.sh
+++ b/src/install_kcov.sh
@@ -11,7 +11,7 @@ GITHUB_KCOV="https://api.github.com/repos/SimonKagstrom/kcov/releases/latest"
 
 # Usage: download and install the latest kcov version by default.
 # Fall back to ${KCOV_DEFAULT_VERSION} from the kcov archive if the latest is unavailable.
-KCOV_VERSION=$(curl -s ${GITHUB_KCOV} | jq -Mr .tag_name || echo)
+KCOV_VERSION=$(curl --silent --show-error --fail ${GITHUB_KCOV} | jq -Mr .tag_name || echo)
 KCOV_VERSION=${KCOV_VERSION:-$KCOV_DEFAULT_VERSION}
 
 KCOV_TGZ="https://github.com/SimonKagstrom/kcov/archive/${KCOV_VERSION}.tar.gz"


### PR DESCRIPTION
I'm recently having build failures (check [jsonschema-validator](https://github.com/macisamuele/jsonschema-validator/tree/e7a11ff2a236dcb76131db6406ec481e04ab6b19/) [travis build](https://travis-ci.com/macisamuele/jsonschema-validator/jobs/152461932#L563)) due to failures in downloading and building `kcov`.

The issue is caused by GitHub API limit from travis IP addresses
```json
{
  "message": "API rate limit exceeded for 35.192.136.167. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
  "documentation_url": "https://developer.github.com/v3/#rate-limiting"
}
```

The goal of this PR is to make the detection of the latest more resilient to API limiting issues.

I manually verified that this works by maning sure that I hit the rate limiting from my IP addresses and testing out the different steps
```
✔ ~/pg/github/cargo-kcov [maci-make-github-api-usage-more-resilient L|✔]
19:09 $ KCOV_DEFAULT_VERSION="DEFAULT_VALUE"
✔ ~/pg/github/cargo-kcov [maci-make-github-api-usage-more-resilient L|✔]
19:10 $ GITHUB_KCOV="https://api.github.com/repos/SimonKagstrom/kcov/releases/latest"
✔ ~/pg/github/cargo-kcov [maci-make-github-api-usage-more-resilient L|✔]
19:10 $ KCOV_VERSION=$(curl --silent --show-error --fail ${GITHUB_KCOV} | jq -Mr .tag_name || echo)
curl: (22) The requested URL returned error: 403 Forbidden
✔ ~/pg/github/cargo-kcov [maci-make-github-api-usage-more-resilient L|✔]
19:10 $ KCOV_VERSION=${KCOV_VERSION:-$KCOV_DEFAULT_VERSION}
✔ ~/pg/github/cargo-kcov [maci-make-github-api-usage-more-resilient L|✔]
19:10 $ echo ${KCOV_VERSION}
DEFAULT_VALUE
✔ ~/pg/github/cargo-kcov [maci-make-github-api-usage-more-resilient L|✔]
19:10 $
```

FYI: @kennytm 